### PR TITLE
Refactor and fix `RangeError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ ASCII85 a.k.a. Base85 implementation in JavaScript
 Methods
 ------------
 
-### `encode(string text[, string charset = 'UTF-8'][, bool useEOD = true])`
-Return ASCII85 encoded `string` of `text` being in `charset`.
+### `encode(string text[, bool useEOD = true])`
+Return ASCII85 encoded `string` of `text`.
 Optionally enclose returned `string` to `<~` and `~>` chars when `useEOD` is true.
 
-### `fromByteArray(Array byteArray[, useEOD = true])`
+### `fromByteArray(Array byteArray[, bool useEOD = true])`
 Return ASCII85 encoded `string` of `byteArray`.
 Optionally enclose returned `string` to `<~` and `~>` chars when `useEOD` is true.
 
-### `decode(string text[, string charset = 'UTF-8'])`
-Return `string` in `charset` of ASCII85 encoded `text`.
+### `decode(string text)`
+Return `string` of ASCII85 encoded `text`.
 
 ### `toByteArray(string text)`
 Return `Uint8Array` of ASCII85 encoded `text`.

--- a/ascii85.js
+++ b/ascii85.js
@@ -145,8 +145,9 @@ let ascii85 = (function () {
         let i = text.startsWith("<~") && text.length > 2 ? 2 : 0;
         do {
             // Skip whitespace
-            if (text.charAt(i).trim().length === 0)
+            if (text.charAt(i).trim().length === 0) {
                 continue;
+            }
 
             let charCode = text.charCodeAt(i);
 
@@ -206,6 +207,6 @@ let ascii85 = (function () {
     }
 })();
 
-let base85 = ascii85;
-if (typeof module !== "undefined" && module.exports) module.exports = ascii85;
-
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = ascii85;
+}

--- a/ascii85.js
+++ b/ascii85.js
@@ -23,7 +23,7 @@
 
 "use strict";
 
-let ascii85 = (function () {
+const ascii85 = (function () {
     const LINE_WIDTH = 80;
     const TUPLE_BITS = [24, 16, 8, 0];
     const POW_85_4 = [
@@ -56,7 +56,7 @@ let ascii85 = (function () {
     }
 
     function fromByteArray(byteArray, useEOD = true) {
-        let output = [];
+        const output = [];
         let lineCounter = 0;
 
         if (useEOD) {
@@ -65,7 +65,7 @@ let ascii85 = (function () {
         }
 
         for (let i = 0; i < byteArray.length; i += 4) {
-            let tuple = new Uint8Array(4);
+            const tuple = new Uint8Array(4);
             let bytes = 4;
 
             for (let j = 0; j < 4; j++) {
@@ -117,7 +117,7 @@ let ascii85 = (function () {
     }
 
     function getByteArrayPart(tuple, bytes = 4) {
-        let output = new Uint8Array(bytes);
+        const output = new Uint8Array(bytes);
 
         for (let i = 0; i < bytes; i++) {
             output[i] = (tuple >> TUPLE_BITS[i]) & 0x00ff;
@@ -128,14 +128,14 @@ let ascii85 = (function () {
 
     function toByteArray(text) {
         function pushPart() {
-            let part = getByteArrayPart(tuple, tupleIndex - 1);
+            const part = getByteArrayPart(tuple, tupleIndex - 1);
             for (let j = 0; j < part.length; j++) {
                 output.push(part[j]);
             }
             tuple = tupleIndex = 0;
         }
 
-        let output = [];
+        const output = [];
         let stop = false;
 
         let tuple = 0;
@@ -148,7 +148,7 @@ let ascii85 = (function () {
                 continue;
             }
 
-            let charCode = text.charCodeAt(i);
+            const charCode = text.charCodeAt(i);
 
             switch (charCode) {
                 case 0x7a: // z

--- a/ascii85.js
+++ b/ascii85.js
@@ -38,7 +38,7 @@ let ascii85 = (function () {
         let output;
         let d = ((tuple[0] << 24) | (tuple[1] << 16) | (tuple[2] << 8) | tuple[3]) >>> 0;
 
-        if (d === 0 && bytes == 4) {
+        if (d === 0 && bytes === 4) {
             output = new Uint8Array(1);
             output[0] = 0x7a; // z
         } else {
@@ -152,7 +152,7 @@ let ascii85 = (function () {
 
             switch (charCode) {
                 case 0x7a: // z
-                    if (tupleIndex != 0) {
+                    if (tupleIndex !== 0) {
                         throw new Exception("Unexpected 'z' character at position " + i);
                     }
 
@@ -163,11 +163,11 @@ let ascii85 = (function () {
                 case 0x7e: // ~
                     let nextChar = "";
                     let j = i + 1;
-                    while (j < text.length && nextChar.trim().length == 0) {
+                    while (j < text.length && nextChar.trim().length === 0) {
                         nextChar = text.charAt(j++);
                     }
 
-                    if (nextChar != ">") {
+                    if (nextChar !== ">") {
                         throw new Exception("Broken EOD at position " + j);
                     }
 
@@ -207,5 +207,5 @@ let ascii85 = (function () {
 })();
 
 let base85 = ascii85;
-if (typeof module != "undefined" && module.exports) module.exports = ascii85;
+if (typeof module !== "undefined" && module.exports) module.exports = ascii85;
 

--- a/ascii85.js
+++ b/ascii85.js
@@ -23,224 +23,187 @@
 
 'use strict';
 
-var ascii85 = (function() {
-	const LINE_WIDTH = 80;
-	const TUPLE_BITS = [24, 16, 8, 0];
-	const POW_85_4 = [
-		85*85*85*85,
-		85*85*85,
-		85*85,
-		85,
-		1
-	];
+var ascii85 = (function () {
+    const LINE_WIDTH = 80;
+    const TUPLE_BITS = [24, 16, 8, 0];
+    const POW_85_4 = [
+        85 * 85 * 85 * 85,
+        85 * 85 * 85,
+        85 * 85,
+        85,
+        1
+    ];
 
-	function getEncodedChunk(tuple, bytes = 4)
-	{
-		var output;
-		let d = ((tuple[0] << 24) | (tuple[1] << 16) | (tuple[2] << 8) | tuple[3]) >>> 0;
+    function getEncodedChunk(tuple, bytes = 4) {
+        var output;
+        let d = ((tuple[0] << 24) | (tuple[1] << 16) | (tuple[2] << 8) | tuple[3]) >>> 0;
 
-		if(d === 0 && bytes == 4)
-		{
-			output = new Uint8Array(1);
-			output[0] = 0x7a; // z
-		}
-		else
-		{
-			output = new Uint8Array(bytes + 1);
+        if (d === 0 && bytes == 4) {
+            output = new Uint8Array(1);
+            output[0] = 0x7a; // z
+        } else {
+            output = new Uint8Array(bytes + 1);
 
-			for(let i = 4; i >= 0; i--)
-			{
-				if(i <= bytes)
-				{
-					output[i] = d % 85 + 0x21; // 0x21 = '!'
-				}
+            for (let i = 4; i >= 0; i--) {
+                if (i <= bytes) {
+                    output[i] = d % 85 + 0x21; // 0x21 = '!'
+                }
 
-				d /= 85;
-			}
-		}
+                d /= 85;
+            }
+        }
 
-		return output;
-	}
+        return output;
+    }
 
-	function fromByteArray (byteArray, useEOD = true)
-	{
-		let output = [];
-		let lineCounter = 0;
+    function fromByteArray(byteArray, useEOD = true) {
+        let output = [];
+        let lineCounter = 0;
 
-		if(useEOD)
-		{
-			output.push(0x3c); // <
-			output.push(0x7e); // ~
-		}
+        if (useEOD) {
+            output.push(0x3c); // <
+            output.push(0x7e); // ~
+        }
 
-		for(let i = 0; i < byteArray.length; i += 4)
-		{
-			let tuple = new Uint8Array(4);
-			let bytes = 4;
+        for (let i = 0; i < byteArray.length; i += 4) {
+            let tuple = new Uint8Array(4);
+            let bytes = 4;
 
-			for(let j = 0; j < 4; j++)
-			{
-				if(i + j < byteArray.length)
-				{
-					tuple[j] = byteArray[i + j];
-				}
-				else
-				{
-					tuple[j] = 0x00;
-					bytes--;
-				}
-			}
+            for (let j = 0; j < 4; j++) {
+                if (i + j < byteArray.length) {
+                    tuple[j] = byteArray[i + j];
+                } else {
+                    tuple[j] = 0x00;
+                    bytes--;
+                }
+            }
 
-			let chunk = getEncodedChunk(tuple, bytes);
-			for(let j = 0; j < chunk.length; j++)
-			{
-				if(lineCounter >= LINE_WIDTH)
-				{
-					output.push(0x0d); // \n
-					lineCounter = 0;
-				}
+            let chunk = getEncodedChunk(tuple, bytes);
+            for (let j = 0; j < chunk.length; j++) {
+                if (lineCounter >= LINE_WIDTH) {
+                    output.push(0x0d); // \n
+                    lineCounter = 0;
+                }
 
-				output.push(chunk[j]);
-				lineCounter++;
-			}
-		}
+                output.push(chunk[j]);
+                lineCounter++;
+            }
+        }
 
-		if(useEOD)
-		{
-			output.push(0x7e); // ~
-			output.push(0x3e); // >
-		}
+        if (useEOD) {
+            output.push(0x7e); // ~
+            output.push(0x3e); // >
+        }
 
-		return String.fromCharCode.apply(null, output);
-	}
+        return String.fromCharCode.apply(null, output);
+    }
 
-	function encode (text)
-	{
-		let charset = 'UTF-8';
-		let useEOD = true;
+    function encode(text) {
+        let charset = 'UTF-8';
+        let useEOD = true;
 
-		if(arguments.length > 1)
-		{
-			if(typeof(arguments[1]) == 'string')
-			{
-				charset = arguments[1];
+        if (arguments.length > 1) {
+            if (typeof (arguments[1]) == 'string') {
+                charset = arguments[1];
 
-				if(arguments.length > 2)
-				{
-					useEOD = !!arguments[2];
-				}
-			}
-			else
-			{
-				useEOD = !!arguments[1];
-			}
-		}
+                if (arguments.length > 2) {
+                    useEOD = !!arguments[2];
+                }
+            } else {
+                useEOD = !!arguments[1];
+            }
+        }
 
-		return fromByteArray(new TextEncoder(charset || "UTF-8").encode(text), useEOD);
-	}
+        return fromByteArray(new TextEncoder(charset || "UTF-8").encode(text), useEOD);
+    }
 
-	function getByteArrayPart(tuple, bytes = 4)
-	{
-		let output = new Uint8Array(bytes);
+    function getByteArrayPart(tuple, bytes = 4) {
+        let output = new Uint8Array(bytes);
 
-		for(let i = 0; i < bytes; i++)
-		{
-			output[i] = (tuple >> TUPLE_BITS[i]) & 0x00ff;
-		}
+        for (let i = 0; i < bytes; i++) {
+            output[i] = (tuple >> TUPLE_BITS[i]) & 0x00ff;
+        }
 
-		return output;
-	}
+        return output;
+    }
 
-	function toByteArray (text)
-	{
-		function pushPart()
-		{
-			let part = getByteArrayPart(tuple, tupleIndex - 1);
-			for(let j = 0; j < part.length; j++)
-			{
-				output.push(part[j]);
-			}
-			tuple = tupleIndex = 0;
-		}
+    function toByteArray(text) {
+        function pushPart() {
+            let part = getByteArrayPart(tuple, tupleIndex - 1);
+            for (let j = 0; j < part.length; j++) {
+                output.push(part[j]);
+            }
+            tuple = tupleIndex = 0;
+        }
 
-		let output = [];
-		let stop = false;
+        let output = [];
+        let stop = false;
 
-		let tuple = 0;
-		let tupleIndex = 0;
+        let tuple = 0;
+        let tupleIndex = 0;
 
-		let i = text.startsWith("<~") && text.length > 2 ? 2 : 0;
-		do
-		{
-			// Skip whitespace
-			if(text.charAt(i).trim().length === 0)
-				continue;
+        let i = text.startsWith("<~") && text.length > 2 ? 2 : 0;
+        do {
+            // Skip whitespace
+            if (text.charAt(i).trim().length === 0)
+                continue;
 
-			let charCode = text.charCodeAt(i);
+            let charCode = text.charCodeAt(i);
 
-			switch(charCode)
-			{
-				case 0x7a: // z
-					if(tupleIndex != 0)
-					{
-						throw new Exception("Unexpected 'z' character at position " + i);
-					}
+            switch (charCode) {
+                case 0x7a: // z
+                    if (tupleIndex != 0) {
+                        throw new Exception("Unexpected 'z' character at position " + i);
+                    }
 
-					for(let j = 0; j < 4; j++)
-					{
-						output.push(0x00);
-					}
-					break;
-				case 0x7e: // ~
-					let nextChar = '';
-					let j = i + 1;
-					while(j < text.length && nextChar.trim().length == 0)
-					{
-						nextChar = text.charAt(j++);
-					}
+                    for (let j = 0; j < 4; j++) {
+                        output.push(0x00);
+                    }
+                    break;
+                case 0x7e: // ~
+                    let nextChar = '';
+                    let j = i + 1;
+                    while (j < text.length && nextChar.trim().length == 0) {
+                        nextChar = text.charAt(j++);
+                    }
 
-					if(nextChar != '>')
-					{
-						throw new Exception("Broken EOD at position " + j);
-					}
+                    if (nextChar != '>') {
+                        throw new Exception("Broken EOD at position " + j);
+                    }
 
-					if(tupleIndex)
-					{
-						tuple += POW_85_4[tupleIndex - 1];
-						pushPart();
-					}
+                    if (tupleIndex) {
+                        tuple += POW_85_4[tupleIndex - 1];
+                        pushPart();
+                    }
 
-					stop = true;
-					break;
-				default:
-					if(charCode < 0x21 || charCode > 0x75)
-					{
-						throw new Exception("Unexpected character with code " + charCode + " at position " + i);
-					}
+                    stop = true;
+                    break;
+                default:
+                    if (charCode < 0x21 || charCode > 0x75) {
+                        throw new Exception("Unexpected character with code " + charCode + " at position " + i);
+                    }
 
-					tuple += (charCode - 0x21) * POW_85_4[tupleIndex++];
-					if(tupleIndex >= 5)
-					{
-						pushPart();
-					}
-			}
-		}
-		while(i++ < text.length && !stop)
+                    tuple += (charCode - 0x21) * POW_85_4[tupleIndex++];
+                    if (tupleIndex >= 5) {
+                        pushPart();
+                    }
+            }
+        }
+        while (i++ < text.length && !stop)
 
-		return new Uint8Array(output);
-	}
+        return new Uint8Array(output);
+    }
 
-	function decode (text, charset)
-	{
-		return new TextDecoder(charset || "UTF-8").decode(toByteArray(text));
-	}
+    function decode(text, charset) {
+        return new TextDecoder(charset || "UTF-8").decode(toByteArray(text));
+    }
 
-	return {
-		fromByteArray: fromByteArray,
-		toByteArray: toByteArray,
-		encode: encode,
-		decode: decode
-	}
+    return {
+        fromByteArray: fromByteArray,
+        toByteArray: toByteArray,
+        encode: encode,
+        decode: decode
+    }
 })();
 
 var base85 = ascii85;

--- a/ascii85.js
+++ b/ascii85.js
@@ -97,23 +97,8 @@ const ascii85 = (function () {
         return String.fromCharCode.apply(null, output);
     }
 
-    function encode(text) {
-        let charset = "UTF-8";
-        let useEOD = true;
-
-        if (arguments.length > 1) {
-            if (typeof (arguments[1]) == "string") {
-                charset = arguments[1];
-
-                if (arguments.length > 2) {
-                    useEOD = !!arguments[2];
-                }
-            } else {
-                useEOD = !!arguments[1];
-            }
-        }
-
-        return fromByteArray(new TextEncoder(charset || "UTF-8").encode(text), useEOD);
+    function encode(text, useEOD = true) {
+        return fromByteArray(new TextEncoder().encode(text), useEOD);
     }
 
     function getByteArrayPart(tuple, bytes = 4) {
@@ -193,8 +178,8 @@ const ascii85 = (function () {
         return new Uint8Array(output);
     }
 
-    function decode(text, charset) {
-        return new TextDecoder(charset || "UTF-8").decode(toByteArray(text));
+    function decode(text) {
+        return new TextDecoder().decode(toByteArray(text));
     }
 
     return {

--- a/ascii85.js
+++ b/ascii85.js
@@ -21,7 +21,7 @@
     SOFTWARE.
  */
 
-'use strict';
+"use strict";
 
 let ascii85 = (function () {
     const LINE_WIDTH = 80;
@@ -46,7 +46,7 @@ let ascii85 = (function () {
 
             for (let i = 4; i >= 0; i--) {
                 if (i <= bytes) {
-                    output[i] = d % 85 + 0x21; // 0x21 = '!'
+                    output[i] = d % 85 + 0x21; // 0x21 = "!"
                 }
 
                 d /= 85;
@@ -99,11 +99,11 @@ let ascii85 = (function () {
     }
 
     function encode(text) {
-        let charset = 'UTF-8';
+        let charset = "UTF-8";
         let useEOD = true;
 
         if (arguments.length > 1) {
-            if (typeof (arguments[1]) == 'string') {
+            if (typeof (arguments[1]) == "string") {
                 charset = arguments[1];
 
                 if (arguments.length > 2) {
@@ -161,13 +161,13 @@ let ascii85 = (function () {
                     }
                     break;
                 case 0x7e: // ~
-                    let nextChar = '';
+                    let nextChar = "";
                     let j = i + 1;
                     while (j < text.length && nextChar.trim().length == 0) {
                         nextChar = text.charAt(j++);
                     }
 
-                    if (nextChar != '>') {
+                    if (nextChar != ">") {
                         throw new Exception("Broken EOD at position " + j);
                     }
 
@@ -207,5 +207,5 @@ let ascii85 = (function () {
 })();
 
 let base85 = ascii85;
-if (typeof module != 'undefined' && module.exports) module.exports = ascii85;
+if (typeof module != "undefined" && module.exports) module.exports = ascii85;
 

--- a/ascii85.js
+++ b/ascii85.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var ascii85 = (function () {
+let ascii85 = (function () {
     const LINE_WIDTH = 80;
     const TUPLE_BITS = [24, 16, 8, 0];
     const POW_85_4 = [
@@ -35,7 +35,7 @@ var ascii85 = (function () {
     ];
 
     function getEncodedChunk(tuple, bytes = 4) {
-        var output;
+        let output;
         let d = ((tuple[0] << 24) | (tuple[1] << 16) | (tuple[2] << 8) | tuple[3]) >>> 0;
 
         if (d === 0 && bytes == 4) {
@@ -206,6 +206,6 @@ var ascii85 = (function () {
     }
 })();
 
-var base85 = ascii85;
+let base85 = ascii85;
 if (typeof module != 'undefined' && module.exports) module.exports = ascii85;
 

--- a/ascii85.js
+++ b/ascii85.js
@@ -48,7 +48,6 @@ let ascii85 = (function () {
                 if (i <= bytes) {
                     output[i] = d % 85 + 0x21; // 0x21 = "!"
                 }
-
                 d /= 85;
             }
         }
@@ -189,8 +188,7 @@ let ascii85 = (function () {
                         pushPart();
                     }
             }
-        }
-        while (i++ < text.length && !stop)
+        } while (i++ < text.length && !stop)
 
         return new Uint8Array(output);
     }

--- a/ascii85.js
+++ b/ascii85.js
@@ -23,7 +23,7 @@
 
 "use strict";
 
-const ascii85 = (function () {
+const ascii85 = (function() {
     const LINE_WIDTH = 80;
     const TUPLE_BITS = [24, 16, 8, 0];
     const POW_85_4 = [
@@ -94,7 +94,11 @@ const ascii85 = (function () {
             output.push(0x3e); // >
         }
 
-        return String.fromCharCode.apply(null, output);
+        return arrayBufferToBinaryString(output);
+    }
+
+    function arrayBufferToBinaryString(arrayBuffer) {
+        return arrayBuffer.reduce((accumulator, byte) => accumulator + String.fromCharCode(byte), "");
     }
 
     function encode(text, useEOD = true) {

--- a/ascii85.js
+++ b/ascii85.js
@@ -198,10 +198,10 @@ const ascii85 = (function () {
     }
 
     return {
-        fromByteArray: fromByteArray,
-        toByteArray: toByteArray,
-        encode: encode,
-        decode: decode
+        fromByteArray,
+        toByteArray,
+        encode,
+        decode
     }
 })();
 

--- a/ascii85.js
+++ b/ascii85.js
@@ -153,7 +153,7 @@ const ascii85 = (function () {
             switch (charCode) {
                 case 0x7a: // z
                     if (tupleIndex !== 0) {
-                        throw new Exception("Unexpected 'z' character at position " + i);
+                        throw new Error("Unexpected 'z' character at position " + i);
                     }
 
                     for (let j = 0; j < 4; j++) {
@@ -168,7 +168,7 @@ const ascii85 = (function () {
                     }
 
                     if (nextChar !== ">") {
-                        throw new Exception("Broken EOD at position " + j);
+                        throw new Error("Broken EOD at position " + j);
                     }
 
                     if (tupleIndex) {
@@ -180,7 +180,7 @@ const ascii85 = (function () {
                     break;
                 default:
                     if (charCode < 0x21 || charCode > 0x75) {
-                        throw new Exception("Unexpected character with code " + charCode + " at position " + i);
+                        throw new Error("Unexpected character with code " + charCode + " at position " + i);
                     }
 
                     tuple += (charCode - 0x21) * POW_85_4[tupleIndex++];

--- a/test/demo-test.js
+++ b/test/demo-test.js
@@ -21,8 +21,8 @@ console.log("[fixed]", wikiExampleOutput === encodedFixed); // true
 
 console.log("[enc-dec]", wikiExampleInput === base85.decode(base85.encode(wikiExampleInput))); // true
 
-// const long = "a".repeat(100000);
-// console.log("[enc-dec][long]", long === base85.decode(base85.encode(long))); // RangeError: Maximum call stack size exceeded
+const long = "a".repeat(1000000);
+console.log("[enc-dec][long]", long === base85.decode(base85.encode(long))); // RangeError: Maximum call stack size exceeded
 
 
 let byteString = "";

--- a/test/demo-test.js
+++ b/test/demo-test.js
@@ -22,7 +22,7 @@ console.log("[fixed]", wikiExampleOutput === encodedFixed); // true
 console.log("[enc-dec]", wikiExampleInput === base85.decode(base85.encode(wikiExampleInput))); // true
 
 const long = "a".repeat(1000000);
-console.log("[enc-dec][long]", long === base85.decode(base85.encode(long))); // RangeError: Maximum call stack size exceeded
+console.log("[enc-dec][long]", long === base85.decode(base85.encode(long))); // No more "RangeError: Maximum call stack size exceeded"
 
 
 let byteString = "";

--- a/test/demo-test.js
+++ b/test/demo-test.js
@@ -1,0 +1,32 @@
+const base85 = require("../ascii85.js");
+
+const wikiExampleInput =
+    "Man is distinguished, not only by his reason, but by this singular passion from "                +
+    "other animals, which is a lust of the mind, that by a perseverance of delight in the continued " +
+    "and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.";
+
+const wikiExampleOutput =
+    "<~9jqo^BlbD-BleB1DJ+*+F(f,q/0JhKF<GL>Cj@.4Gp$d7F!,L7@<6@)/0JDEF<G%<+EV:2F!,"   +
+    "O<DJ+*.@<*K0@<6L(Df-\\0Ec5e;DffZ(EZee.Bl.9pF\"AGXBPCsi+DGm>@3BB/F*&OCAfu2/AKY" +
+    "i(DIb:@FD,*)+C]U=@3BN#EcYf8ATD3s@q?d$AftVqCh[NqF<G:8+EV:.+Cf>-FD5W8ARlolDIa"   +
+    "l(DId<j@<?3r@:F%a+D58'ATD4$Bl@l3De:,-DJs`8ARoFb/0JMK@qB4^F!,R<AKZ&-DfTqBG%G"   +
+    ">uD.RTpAKYo'+CT/5+Cei#DII?(E,9)oF*2M7/c~>";
+
+
+const encoded = base85.encode(wikiExampleInput);
+const encodedFixed = encoded.replaceAll("\r", "");
+
+console.log("[orig] ", wikiExampleOutput === encoded);      // false
+console.log("[fixed]", wikiExampleOutput === encodedFixed); // true
+
+console.log("[enc-dec]", wikiExampleInput === base85.decode(base85.encode(wikiExampleInput))); // true
+
+// const long = "a".repeat(100000);
+// console.log("[enc-dec][long]", long === base85.decode(base85.encode(long))); // RangeError: Maximum call stack size exceeded
+
+
+let byteString = "";
+for (let i = 0; i < 256; i++) {
+    byteString += String.fromCharCode(i);
+}
+console.log("[enc-dec-bs]", byteString === base85.decode(base85.encode(byteString)));

--- a/test/demo-test.js
+++ b/test/demo-test.js
@@ -30,3 +30,10 @@ for (let i = 0; i < 256; i++) {
     byteString += String.fromCharCode(i);
 }
 console.log("[enc-dec-bs]", byteString === base85.decode(base85.encode(byteString)));
+
+
+const dataUrl = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA+SURBVEhL7dIxCgAwCMVQ739pu/yh0JYgXfNWlSxWv9UhgwkDyAAygAygXEo/8k032dhkMGEAGUAGkAHQvQC3veR+Ql0lAQAAAABJRU5ErkJggg==`;
+const base64ImageData = dataUrl.slice("data:image/png;base64,".length);
+const base85ImageData = base85.encode(atob(base64ImageData));
+console.log("base64.length", base64ImageData.length, "base85.length", base85ImageData.length);  // base64.length 228 base85.length 271
+console.log("[enc-dec][image]", base64ImageData === btoa(base85.decode(base85ImageData)));      // true


### PR DESCRIPTION
- The code was ~refactored~ formatted.
- `RangeError: Maximum call stack size exceeded` error was fixed. https://github.com/nE0sIghT/ascii85.js/commit/28d13bc656cfcc2fc7c356066e8ffe51fa3d5dde
- `charset` arg was removed since `TextEncoder` supports only UTF-8. https://github.com/nE0sIghT/ascii85.js/commit/2522628fd68ffcf4424cef75a6c573b431786da8
- `Exception`'s was replaces with `Error`. Since there is no `Exception` class by default in JS. https://github.com/nE0sIghT/ascii85.js/pull/3/commits/6a4d5f2be9da05a4420a8fa8613121ce615ddbf6
- Add simple demo/test file. https://github.com/nE0sIghT/ascii85.js/pull/3/commits/f20074b311033245d030d8b9777e8a6eedd75eba

Probably, I did something wrong, but after rechecking using `TextDecoder`/`TextEncoder` looks to be OK in your case, the code works, so I leave them. https://github.com/nE0sIghT/ascii85.js/issues/2

Also your code adds `\r` characters, they looks to be unnecessary. Check the demo.

More over, the result of `encode` for binary string takes notable more space that `btoa`, so there is no sense to use it.

_I just wanted to use base85 for storing images in `chrome.store.local` (Web Extension store), since I expected that it would be more effective than base64._



